### PR TITLE
Replace textarea with ace editor. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,38 @@
 .idea/*
+# Created by https://www.gitignore.io/api/bower,osx
+
+### Bower ###
+bower_components
+.bower-cache
+.bower-registry
+.bower-tmp
+
+### OSX ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+# End of https://www.gitignore.io/api/bower,osx

--- a/src/bower.json
+++ b/src/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "jsinjector",
+  "homepage": "https://github.com/lnaia/jsinjector",
+  "authors": [
+    "lnaia"
+  ],
+  "description": "This chrome extension has the purpose of injecting Javascript into a target URL every time that page loads.",
+  "main": "",
+  "license": "GPL 3",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "angular-ui-ace": "bower"
+  }
+}

--- a/src/css/options.css
+++ b/src/css/options.css
@@ -3,6 +3,9 @@ body {
     padding-top: 30px;
     background-color: #fbfbfb;
 }
+.ace_editor {
+    height: 200px;
+}
 
 table.regex-list {
     -webkit-border-radius: 3px;

--- a/src/js/app.angular.js
+++ b/src/js/app.angular.js
@@ -1,7 +1,7 @@
 (function (chrome, $) {
   'use strict';
 
-  angular.module('options', ['ui.bootstrap'])
+  angular.module('options', ['ui.bootstrap', 'ui.ace'])
 
     .factory('duplicateTagTooltip', function () {
       return {

--- a/src/js/options.controller.js
+++ b/src/js/options.controller.js
@@ -22,6 +22,7 @@
         });
       }
 
+      $scope.addNewItem = addNewItem;
       $scope.showForm = false;
       $scope.edit = {};
 
@@ -29,6 +30,12 @@
         $scope.manifest = data;
       });
 
+      function addNewItem(){
+        if(!$scope.showForm) {
+          $scope.inject = {code: '', url: 'https://example.com/*'};
+          $scope.showForm = true;
+        }
+      }
       $scope.save = function (item) {
 
         if (item.$$hashKey) {
@@ -70,7 +77,7 @@
 
       listItems();
       if ($location.path() === '/add') {
-        $scope.showForm = true;
+        addNewItem();
       }
 
     }

--- a/src/options.html
+++ b/src/options.html
@@ -5,7 +5,6 @@
     <link href="css/bootstrap.min.css" rel="stylesheet">
     <link href="css/bootstrap-theme.min.css" rel="stylesheet">
     <link href="css/options.css" rel="stylesheet">
-    <script src="js/angular.min.js"></script>
 </head>
 <body>
 
@@ -23,7 +22,7 @@
             </div>
 
             <div class="col-sm-2">
-                <button ng-click="showForm = true" type="button" class="btn btn-primary btn-block" id="add">Add</button>
+                <button ng-click="addNewItem()" type="button" class="btn btn-primary btn-block" ng-disabled="!!showForm" id="add">Add</button>
             </div>
 
             <div class="col-sm-1">
@@ -64,8 +63,16 @@
                        href="https://developer.chrome.com/extensions/storage#property-sync-QUOTA_BYTES_PER_ITEM">
                         Javascript code max 4,096 bytes
                     </a>
-                    <textarea ng-model="inject.code" placeholder="Javascript code"
-                              class="form-control" rows="8"></textarea>
+                    <div ng-if="showForm" ui-ace="{
+                        mode: 'javascript',
+                        useWrapMode : true,
+                        showGutter: true,
+                        advanced: {
+                            enableBasicAutocompletion: true,
+                            enableSnippets: true,
+                            enableLiveAutocompletion: false
+                        }
+                    }" ng-model="inject.code"></div>
                     <button ng-click="save(inject)" class="btn btn-info btn-xs">Save</button>
                     <button ng-click="showForm = false" class="btn btn-default btn-xs">Cancel</button>
                 </td>
@@ -94,7 +101,16 @@
             </tr>
             <tr ng-show="edit[item.guid]" ng-repeat-end>
                 <td class="jscode" colspan="3">
-                    <textarea ng-model="item.code" class="form-control" rows="8">{{ item.code }}</textarea>
+                    <div ng-if="edit[item.guid]" ui-ace="{
+                        mode: 'javascript',
+                        useWrapMode : true,
+                        showGutter: true,
+                        advanced: {
+                            enableBasicAutocompletion: true,
+                            enableSnippets: true,
+                            enableLiveAutocompletion: false
+                        }
+                    }" ng-model="item.code"></div>
                     <button ng-click=" save(item); edit[item.guid] = false" class="btn btn-info btn-xs">Save</button>
                     <button ng-click="edit[item.guid] = false" class="btn btn-default btn-xs">Cancel</button>
                 </td>
@@ -107,11 +123,17 @@
     </footer>
 </div>
 
-<script src="js/ui-bootstrap-tpls-0.11.0.min.js"></script>
-<script src="js/jquery-2.1.1.min.js"></script>
-<script src="js/bootstrap.min.js"></script>
-<script src="js/app.angular.js"></script>
-<script src="js/options.controller.js"></script>
-<script src="js/help.controller.js"></script>
+<script defer type="application/javascript" src="js/jquery-2.1.1.min.js"></script>
+<script defer type="application/javascript" src="js/bootstrap.min.js"></script>
+<script defer type="application/javascript" src="bower_components/ace-builds/src-min-noconflict/ace.js"></script>
+<script defer type="application/javascript" src="bower_components/ace-builds/src-min-noconflict/ext-language_tools.js "></script>
+<script defer type="application/javascript" src="bower_components/ace-builds/src-min-noconflict/mode-javascript.js"></script>
+<script defer type="application/javascript" src="js/angular.min.js"></script>
+<script defer type="application/javascript" src="js/ui-bootstrap-tpls-0.11.0.min.js"></script>
+<script defer type="application/javascript" src="bower_components/angular-ui-ace/ui-ace.min.js"></script>
+
+<script defer type="application/javascript" src="js/app.angular.js"></script>
+<script defer type="application/javascript" src="js/options.controller.js"></script>
+<script defer type="application/javascript" src="js/help.controller.js"></script>
 </body>
 </html>


### PR DESCRIPTION
For personal use I swapped out the textarea for [angular-ui/ui-ace](https://github.com/angular-ui/ui-ace). With ace as code editor you get code highlighting, code completion and basic error validation.

The change is quite big, it introduces a dependency to bower and loads quite a bit more javascript on the options page. The bower_components directory is currently configured to be created within the src/* dir which may not be optimal for your setup.

Feel free to review the code and let me know if you're interested in merging the change. I can clean up the work tree to drop the bower dependency and directly include the required libraries within `js/`.